### PR TITLE
Fixing bug for getWeights for StaticSynapse

### DIFF
--- a/pynn_genn/projections.py
+++ b/pynn_genn/projections.py
@@ -200,10 +200,10 @@ class Projection(common.Projection, ContextMixin):
                     # Get slice of variable matrix
                     sub_var = var[sub.pre_slice, sub.post_slice]
 
-                    if n in sub_pop.syn_pop.vars:
-                        sub_var[sub_pre_inds,sub_post_inds] = sub.syn_pop.get_var_values(n)
-                    else:
-                        sub_var[sub_pre_inds,sub_post_inds] = sub.wum_params[n]
+                    sub_var[sub_pre_inds,sub_post_inds] =\
+                        sub.wum_params[n]\
+                        if n in sub.wum_params else\
+                        sub.syn_pop.get_var_values(n)
 
                 # Add variable to list
                 variables.append(var)
@@ -224,8 +224,10 @@ class Projection(common.Projection, ContextMixin):
                     # Reshape variable values from sub-population
                     # and copy into slice of var
                     var[sub.pre_slice, sub.post_slice] =\
-                        np.reshape(sub.syn_pop.get_var_values(n),
-                                   sub_shape)
+                        sub.wum_params[n]\
+                        if n in sub.wum_params else\
+                        np.reshape(sub.syn_pop.get_var_values(n),sub_shape)
+
                 # Add variable to list
                 variables.append(var)
 

--- a/pynn_genn/projections.py
+++ b/pynn_genn/projections.py
@@ -200,10 +200,10 @@ class Projection(common.Projection, ContextMixin):
                     # Get slice of variable matrix
                     sub_var = var[sub.pre_slice, sub.post_slice]
 
-                    sub_var[sub_pre_inds,sub_post_inds] =\
-                        sub.wum_params[n]\
-                        if n in sub.wum_params else\
-                        sub.syn_pop.get_var_values(n)
+                    if n in sub.wum_params:
+                        sub_var[sub_pre_inds,sub_post_inds] = sub.wum_params[n]
+                    else:
+                        sub_var[sub_pre_inds,sub_post_inds] = sub.syn_pop.get_var_values(n)
 
                 # Add variable to list
                 variables.append(var)
@@ -223,10 +223,11 @@ class Projection(common.Projection, ContextMixin):
 
                     # Reshape variable values from sub-population
                     # and copy into slice of var
-                    var[sub.pre_slice, sub.post_slice] =\
-                        sub.wum_params[n]\
-                        if n in sub.wum_params else\
-                        np.reshape(sub.syn_pop.get_var_values(n),sub_shape)
+                    if n in sub.wum_params:
+                        var[sub.pre_slice, sub.post_slice] = sub.wum_params[n]
+                    else:
+                        var[sub.pre_slice, sub.post_slice] =\
+                            np.reshape(sub.syn_pop.get_var_values(n),sub_shape)
 
                 # Add variable to list
                 variables.append(var)


### PR DESCRIPTION
I realized using `wum_params` for checking whether the variable is present or not is a better idea since `sub_pop` object is dependent on the previous loop [(L179)](https://github.com/genn-team/pynn_genn/blob/master/pynn_genn/projections.py#L179). Also, this was not implemented for dense projection and hence implemented it.