### PR TITLE
Simulator setup option to reuse existing GeNN model

### DIFF
--- a/pynn_genn/__init__.py
+++ b/pynn_genn/__init__.py
@@ -47,6 +47,7 @@ def setup(timestep=DEFAULT_TIMESTEP, min_delay=DEFAULT_MIN_DELAY,
     simulator.state.max_delay = max_delay
     simulator.state.mpi_rank = extra_params.get("rank", 0)
     simulator.state.num_processes = extra_params.get("num_processes", 1)
+    simulator.state.reuse_genn_model = extra_params.get("reuse_genn_model", False)
 
     # If backend is specified, use that
     if "backend" in extra_params:

--- a/pynn_genn/simulator.py
+++ b/pynn_genn/simulator.py
@@ -69,9 +69,10 @@ class State(common.control.BaseState):
             model_exists = os.path.isfile(os.path.join(self.model_path, 
                                                        "runner_Release.dll"))
         else:
-            model_exists = os.path.isfile(os.path.join(self.model_path, 
-                                                       self.name + "_CODE",
-                                                       "librunner.so"))
+            model_exists = os.path.isfile(
+                os.path.join(self.model_path, 
+                             self.model.model_name + "_CODE",
+                             "librunner.so"))
         if not self.reuse_genn_model or not model_exists:
             self.model.build(self.model_path)
         self.model.load(self.model_path)

--- a/pynn_genn/simulator.py
+++ b/pynn_genn/simulator.py
@@ -1,6 +1,9 @@
-from pyNN import common
-from pygenn import GeNNModel
+import os
 from six import iteritems, itervalues
+
+from pyNN import common
+
+from pygenn import GeNNModel
 
 name = "genn"
 
@@ -24,6 +27,7 @@ class State(common.control.BaseState):
         self.dt = 0.1
         self.t = 0.0
         self.num_current_sources = 0
+        self.reuse_genn_model = False
         self.native_rng = None
 
     @property
@@ -58,7 +62,18 @@ class State(common.control.BaseState):
         for proj in self.projections:
             proj._create_native_projection()
 
-        self.model.build(self.model_path)
+        # Build and load GeNN model
+        # **THINK** this logic is common with mlGeNN so maybe
+        # model_filename should be a GeNNModel property?
+        if os.name == 'nt':
+            model_exists = os.path.isfile(os.path.join(self.model_path, 
+                                                       "runner_Release.dll"))
+        else:
+            model_exists = os.path.isfile(os.path.join(self.model_path, 
+                                                       self.name + "_CODE",
+                                                       "librunner.so"))
+        if not self.reuse_genn_model or not model_exists:
+            self.model.build(self.model_path)
         self.model.load(self.model_path)
 
         self._built = True


### PR DESCRIPTION
Previously there was actually no way to reuse a previously compiled model in PyNN GeNN. This PR adds a ``reuse_genn_model`` option to the simulator ``setup`` function which behaves in the same way as the corresponding mlGeNN option.

Slightly irritatingly, having this logic duplicated in frontend libraries means they'll all need to be updated when we fix https://github.com/genn-team/genn/issues/389.

Also, the _real_ solution is to make GeNN smarter and only rebuild code when something changes.