### PR TITLE
Current Sources count also needed resetting

### DIFF
--- a/pynn_genn/simulator.py
+++ b/pynn_genn/simulator.py
@@ -117,6 +117,7 @@ class State(common.control.BaseState):
         # we need to reset these for reusing built models to work
         common.Projection._nProj = 0
         common.Population._nPop = 0
+        self.num_current_sources = 0
 
         self.populations = []
         self.projections = []


### PR DESCRIPTION
We were generating unique Current Sources' variable names with a postfix which references a count to how many current sources the simulator has created (after injection). This count was not reset (to zero) in the simulator.clear() function so it led to the reuse_genn_model flag to break the simulation since it was looking for a different name. 

I extended the test for #57 so it covers Current Sources as well.
 
Thanks to @koch-r for reporting (in issue #58) and finding the solution to this bug!