### PR TITLE
Using Numpy test_array_XXX leads to errors about a scalar's Attribute

### DIFF
--- a/test/system/scenarios/test_connection_handling.py
+++ b/test/system/scenarios/test_connection_handling.py
@@ -5,7 +5,8 @@ Tests of the fine-grained connection API
 
 from __future__ import division
 from nose.tools import assert_equal, assert_almost_equal, assert_is_instance
-from numpy.testing import assert_array_equal
+#from numpy.testing import assert_array_equal
+from pyNN.utility import assert_arrays_equal
 import numpy as np
 from pyNN import common
 from .registry import register
@@ -41,7 +42,7 @@ def connection_access_weight_and_delay(sim):
     target[:, 1] = 0.5
     target[2, 0] = 0.0123
     target[2, 1] = 1.0
-    assert_array_equal(np.array(prj.get(('weight', 'delay'), format='list', with_address=False)),
+    assert_arrays_equal(np.array(prj.get(('weight', 'delay'), format='list', with_address=False)),
                        target)
 connection_access_weight_and_delay.__test__ = False
 

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -1,10 +1,11 @@
 
 
 from nose.tools import assert_equal, assert_true, assert_false, assert_raises
-from numpy.testing import assert_array_equal
+# from numpy.testing import assert_array_equal
 import quantities as pq
 import numpy
 from .registry import register
+from pyNN.utility import assert_arrays_equal, assert_arrays_almost_equal
 
 try:
     import scipy
@@ -96,7 +97,7 @@ def issue321(sim):
     v = cells.get_data().segments[0].filter(name='v')[0]
     sim.end()
     # the DCSource and StepCurrentSource should be equivalent
-    assert_array_equal(v[:, 1], v[:, 2])
+    assert_arrays_almost_equal(v[:, 1], v[:, 2], 0.001)
     # Ideally, the three cells should have identical traces, but in
     # practice there is always a delay with NEST until the current from
     # a current generator kicks in

--- a/test/system/scenarios/test_parameter_handling.py
+++ b/test/system/scenarios/test_parameter_handling.py
@@ -1,7 +1,7 @@
 
 import numpy
 from numpy import nan
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+#from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_equal
 from pyNN.utility import assert_arrays_equal, assert_arrays_almost_equal
 from .registry import register
@@ -125,21 +125,21 @@ def test_set_synaptic_parameters_partially_connected(sim):
     expected = positional_weights
     actual = prj.get('weight', format='array')
     if mpi_rank == 0:
-        assert_array_equal(actual, expected)
+        assert_arrays_equal(actual, expected)
 
     u_list = [0.9, 0.8, 0.7, 0.6, 0.5]
     prj.set(U=u_list)
     expected = numpy.array([[0.9, nan], [0.8, 0.7], [nan, 0.6], [0.5, nan]])
     actual = prj.get('U', format='array')
     if mpi_rank == 0:
-        assert_array_equal(actual, expected)
+        assert_arrays_equal(actual, expected)
 
     f_delay = lambda d: 0.5 + d
     prj.set(delay=f_delay)
     expected = numpy.array([[0.5, nan], [1.5, 0.5], [nan, 1.5], [3.5, nan]])
     actual = prj.get('delay', format='array')
     if mpi_rank == 0:
-        assert_array_equal(actual, expected)
+        assert_arrays_equal(actual, expected)
 
     # final sanity check
     expected = numpy.array([
@@ -152,7 +152,7 @@ def test_set_synaptic_parameters_partially_connected(sim):
     actual = numpy.array(prj.get(['weight', 'delay', 'U'], format='list'))
     if mpi_rank == 0:
         ind = numpy.lexsort((actual[:, 1], actual[:, 0]))
-        assert_array_equal(actual[ind], expected)
+        assert_arrays_equal(actual[ind], expected)
 test_set_synaptic_parameters_partially_connected.__test__ = False
 
 
@@ -236,7 +236,7 @@ def test_set_synaptic_parameters_multiply_connected(sim):
     actual = numpy.array(prj.get(['weight', 'delay', 'U'], format='list'))
     if mpi_rank == 0:
         ind = numpy.lexsort((actual[:, 1], actual[:, 0]))
-        assert_array_equal(actual[ind], expected)
+        assert_arrays_equal(actual[ind], expected)
 test_set_synaptic_parameters_multiply_connected.__test__ = False
 
 

--- a/test/system/scenarios/test_recording.py
+++ b/test/system/scenarios/test_recording.py
@@ -3,7 +3,7 @@ import os
 import numpy
 import quantities as pq
 from nose.tools import assert_equal, assert_true
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+#from numpy.testing import assert_array_equal, assert_array_almost_equal
 from neo.io import get_io
 from pyNN.utility import assert_arrays_equal, assert_arrays_almost_equal, init_logging, normalized_filename
 from .registry import register
@@ -34,8 +34,8 @@ def test_reset_recording(sim):
     sim.end()
     ti = lambda i: data.segments[i].analogsignals[0].times
     assert_arrays_equal(ti(0), ti(1))
-    assert_array_equal(data.segments[0].analogsignals[0].channel_index.channel_ids, numpy.array([3]))
-    assert_array_equal(data.segments[1].analogsignals[0].channel_index.channel_ids, numpy.array([4]))
+    assert_arrays_equal(data.segments[0].analogsignals[0].channel_index.channel_ids, numpy.array([3]))
+    assert_arrays_equal(data.segments[1].analogsignals[0].channel_index.channel_ids, numpy.array([4]))
     vi = lambda i: data.segments[i].analogsignals[0]
     assert vi(0).shape == vi(1).shape == (101, 1)
     assert vi(0)[0, 0] == vi(1)[0, 0] == p.initial_values['v'].evaluate(simplify=True) * pq.mV  # the first value should be the same
@@ -80,20 +80,20 @@ def test_record_vm_and_gsyn_from_assembly(sim):
     assert_equal(gsyn_p1.shape, (n_points, 4))
     assert_equal(gsyn_all.shape, (n_points, 7))
 
-    assert_array_equal(vm_p1[:, 3], vm_all[:, 8])
+    assert_arrays_equal(vm_p1[:, 3], vm_all[:, 8])
 
-    assert_array_equal(vm_p0.channel_index.index, numpy.arange(5))
-    assert_array_equal(vm_p1.channel_index.index, numpy.arange(6))
-    assert_array_equal(vm_all.channel_index.index, numpy.arange(11))
-    assert_array_equal(vm_p0.channel_index.channel_ids, numpy.arange(5))
-    assert_array_equal(vm_p1.channel_index.channel_ids, numpy.arange(6))
-    assert_array_equal(vm_all.channel_index.channel_ids, numpy.arange(11))
-    assert_array_equal(gsyn_p0.channel_index.index, numpy.arange(3))
-    assert_array_equal(gsyn_p1.channel_index.index, numpy.arange(4))
-    assert_array_equal(gsyn_all.channel_index.index, numpy.arange(7))
-    assert_array_equal(gsyn_p0.channel_index.channel_ids, numpy.array([2, 3, 4]))
-    assert_array_equal(gsyn_p1.channel_index.channel_ids, numpy.arange(4))
-    assert_array_equal(gsyn_all.channel_index.channel_ids, numpy.arange(2, 9))
+    assert_arrays_equal(vm_p0.channel_index.index, numpy.arange(5))
+    assert_arrays_equal(vm_p1.channel_index.index, numpy.arange(6))
+    assert_arrays_equal(vm_all.channel_index.index, numpy.arange(11))
+    assert_arrays_equal(vm_p0.channel_index.channel_ids, numpy.arange(5))
+    assert_arrays_equal(vm_p1.channel_index.channel_ids, numpy.arange(6))
+    assert_arrays_equal(vm_all.channel_index.channel_ids, numpy.arange(11))
+    assert_arrays_equal(gsyn_p0.channel_index.index, numpy.arange(3))
+    assert_arrays_equal(gsyn_p1.channel_index.index, numpy.arange(4))
+    assert_arrays_equal(gsyn_all.channel_index.index, numpy.arange(7))
+    assert_arrays_equal(gsyn_p0.channel_index.channel_ids, numpy.array([2, 3, 4]))
+    assert_arrays_equal(gsyn_p1.channel_index.channel_ids, numpy.arange(4))
+    assert_arrays_equal(gsyn_all.channel_index.channel_ids, numpy.arange(2, 9))
 
     sim.end()
 test_record_vm_and_gsyn_from_assembly.__test__ = False
@@ -158,8 +158,9 @@ def test_mix_procedural_and_oo(sim):
 
     data_proc = get_io(fn_proc).read()[0]
     data_oo = get_io(fn_oo).read()[0]
-    assert_array_equal(data_proc.segments[0].analogsignals[0],
-                       data_oo.segments[0].analogsignals[0])
+    assert_arrays_almost_equal(data_proc.segments[0].analogsignals[0],
+                               data_oo.segments[0].analogsignals[0],
+                               0.01)
 
     os.remove(fn_proc)
     os.remove(fn_oo)

--- a/test/system/scenarios/test_simulation_control.py
+++ b/test/system/scenarios/test_simulation_control.py
@@ -1,6 +1,6 @@
 
 from nose.tools import assert_almost_equal, assert_raises
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+# from numpy.testing import assert_array_equal, assert_array_almost_equal
 from pyNN.utility import assert_arrays_equal, assert_arrays_almost_equal
 from .registry import register
 
@@ -25,8 +25,8 @@ def test_reset(sim):
 
     assert len(data.segments) == repeats
     for segment in data.segments[1:]:
-        assert_array_almost_equal(segment.analogsignals[0],
-                                  data.segments[0].analogsignals[0], 10)
+        assert_arrays_almost_equal(segment.analogsignals[0],
+                                   data.segments[0].analogsignals[0], 1e-10)
 test_reset.__test__ = False
 
 
@@ -53,7 +53,7 @@ def test_reset_with_clear(sim):
     for rec in data:
         assert len(rec.segments) == 1
         assert_arrays_almost_equal(rec.segments[0].analogsignals[0],
-                                   data[0].segments[0].analogsignals[0], 1e-11)
+                                   data[0].segments[0].analogsignals[0], 1e-10)
 test_reset_with_clear.__test__ = False
 
 
@@ -80,7 +80,9 @@ def test_setup(sim):
         assert len(block.segments) == 1
         signals = block.segments[0].analogsignals
         assert len(signals) == 1
-        assert_array_equal(signals[0], data[0].segments[0].analogsignals[0])
+        assert_arrays_almost_equal(signals[0],
+                                   data[0].segments[0].analogsignals[0],
+                                   1e-10)
 test_setup.__test__ = False
 
 


### PR DESCRIPTION
The thrown error is `AttributeError: 'float' object has no attribute 't_start'`. Using PyNN test_arrays_XXX the problem disappears, it's a bit odd because they anyhow use Numpy to do the test in the end. 